### PR TITLE
Serialization and transaction signing tool (RIPD-1309):

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Ignore build files
+build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extras/ripple-libpp"]
+	path = extras/ripple-libpp
+	url = https://github.com/ripple/ripple-libpp.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,91 @@
+sudo: false
+language: cpp
+
+env:
+  global:
+    - LLVM_VERSION=3.8.0
+    # Maintenance note: to move to a new version
+    # of boost, update both BOOST_ROOT and BOOST_URL.
+    # Note that for simplicity, BOOST_ROOT's final
+    # namepart must match the folder name internal
+    # to boost's .tar.gz.
+    - LCOV_ROOT=$HOME/lcov
+    - LCOV_EXCLUDE_FILES="*/src/test/*"
+    - BOOST_ROOT=$HOME/boost_1_64_0
+    - BOOST_URL='http://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.gz'
+
+addons:
+  apt:
+    sources: ['ubuntu-toolchain-r-test']
+    packages:
+      - gcc-5
+      - g++-5
+      - python-software-properties
+      - protobuf-compiler
+      - libprotobuf-dev
+      - libssl-dev
+      - libstdc++6
+      - binutils-gold
+      # Provides a backtrace if the unittests crash
+      - gdb
+
+matrix:
+  include:
+    # Default BUILD is scons. Default APP is rippled.
+
+    - compiler: gcc
+      env:
+      - GCC_VER=5
+      - TARGET=coverage
+      - PATH=$PWD/cmake/bin:$PATH
+      - APP=ripple-offline-tool
+      - APP_ARGS=--unittest
+      - BUILD=cmake
+
+    - compiler: clang
+      env:
+      - GCC_VER=5
+      - TARGET=debug
+      - CLANG_VER=3.8
+      - PATH=$PWD/llvm-$LLVM_VERSION/bin:$PWD/cmake/bin:$PATH
+      - APP=ripple-offline-tool
+      - APP_ARGS=--unittest
+      - BUILD=cmake
+
+    - compiler: gcc
+      env:
+      - GCC_VER=5
+      - TARGET=release
+      - PATH=$PWD/cmake/bin:$PATH
+      - APP=ripple-offline-tool
+      - APP_ARGS=--unittest
+      - BUILD=cmake
+
+    - compiler: clang
+      env:
+      - GCC_VER=5
+      - TARGET=release
+      - CLANG_VER=3.8
+      - PATH=$PWD/llvm-$LLVM_VERSION/bin:$PWD/cmake/bin:$PATH
+      - APP=ripple-offline-tool
+      - APP_ARGS=--unittest
+      - BUILD=cmake
+
+cache:
+  directories:
+  - $BOOST_ROOT
+  - llvm-$LLVM_VERSION
+  - cmake
+
+before_install:
+  - ( cd extras/ripple-libpp/extras/rippled && bin/ci/ubuntu/install-dependencies.sh ../../../.. )
+
+script:
+  - extras/ripple-libpp/extras/rippled/bin/ci/ubuntu/build-and-test.sh
+
+notifications:
+  email:
+    false
+  irc:
+    channels:
+      - "chat.freenode.net#ripple-dev"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,133 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/extras/ripple-libpp/extras/rippled/Builds/CMake")
+include(CMakeFuncs)
+
+set(openssl_min 1.0.1)
+
+parse_target()
+
+if (nonunity)
+  set(target "" CACHE STRING "Build target. Nounity not supported" FORCE)
+  message(FATAL_ERROR "Nonunity builds not supported")
+endif()
+
+setup_build_cache()
+
+project(ripple-offline-tool)
+
+############################################################
+
+determine_build_type()
+
+check_gcc4_abi()
+
+############################################################
+
+include_directories(
+  src/
+  SYSTEM
+  extras/ripple-libpp/extras/rippled/src
+  extras/ripple-libpp/extras/rippled/src/beast/include
+  extras/ripple-libpp/extras/rippled/src/beast/extras)
+
+special_build_flags()
+
+############################################################
+
+use_boost(
+  filesystem
+  program_options
+  regex
+  system
+  thread)
+
+use_pthread()
+
+use_openssl(${openssl_min})
+
+setup_build_boilerplate()
+
+############################################################
+
+add_with_props(lib_src extras/ripple-libpp/src/unity/ripple-libpp.cpp
+  -I"${CMAKE_SOURCE_DIR}/"extras/ripple-libpp/extras/rippled/src/secp256k1
+  ${no_unused_w}
+  )
+
+add_with_props(lib_src extras/ripple-libpp/extras/rippled/src/ripple/unity/ed25519_donna.c
+  -I"${CMAKE_SOURCE_DIR}/"extras/ripple-libpp/extras/rippled/src/ed25519-donna)
+
+############################################################
+
+prepend(app_src
+  src/
+  RippleKey.cpp
+  Serialize.cpp
+  OfflineTool.cpp
+  test/RippleKey_test.cpp
+  test/Serialize_test.cpp
+  test/OfflineTool_test.cpp)
+
+############################################################
+
+if (WIN32 OR is_xcode)
+  # Rippled sources
+  foreach(curdir
+      beast/core
+      beast/hash
+      beast/utility
+      basics
+      core
+      crypto
+      json
+      protocol)
+    file(GLOB_RECURSE cursrcs extras/ripple-libpp/extras/rippled/src/ripple/${curdir}/*.h
+      extras/ripple-libpp/extras/rippled/src/ripple/${curdir}/*.cpp)
+    list(APPEND rippled_src "${cursrcs}")
+    list(APPEND non_unity_srcs "${cursrcs}")
+  endforeach()
+
+  file(GLOB_RECURSE all_headers src/*.hpp extras/*.hpp src/*.h)
+  list(APPEND rippled_src "${all_headers}")
+
+  # Properties
+  set_property(
+    SOURCE ${non_unity_srcs}
+    APPEND
+    PROPERTY HEADER_FILE_ONLY
+    true)
+  set_property(
+    SOURCE ${all_headers}
+    APPEND
+    PROPERTY HEADER_FILE_ONLY
+    true)
+    # Doesn't work
+    # $<OR:$<CONFIG:Debug>,$<CONFIG:Release>>)
+endif()
+
+############################################################
+
+if (NOT is_msvc)
+  set(no_unused_w -Wno-unused-function)
+else()
+  unset(no_unused_w)
+endif()
+
+############################################################
+
+if (WIN32 OR is_xcode)
+  group_sources(src)
+  group_sources(extras/ripple-libpp/extras/rippled/src)
+endif()
+
+add_library(ripplelibpp OBJECT ${lib_src} ${rippled_src})
+
+add_executable(ripple-offline-tool ${app_src} $<TARGET_OBJECTS:ripplelibpp> ${rippled_src})
+
+set_startup_project(ripple-offline-tool)
+
+target_link_libraries(ripple-offline-tool
+  ${OPENSSL_LIBRARIES} ${SANITIZER_LIBRARIES})
+
+link_common_libraries(ripple-offline-tool)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,77 @@
+The accompanying files under various copyrights.
+
+Copyright (c) 2017 Ripple Labs Inc.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The accompanying files incorporate work covered by the following copyright
+and previous license notice:
+
+Copyright (c) 2011 Arthur Britto, David Schwartz, Jed McCaleb,
+Vinnie Falco, Bob Way, Eric Lombrozo, Nikolaos D. Bougalis, Howard Hinnant
+
+Some code from Raw Material Software, Ltd., provided under the terms of the
+  ISC License. See the corresponding source files for more details.
+  Copyright (c) 2013 - Raw Material Software Ltd.
+  Please visit http://www.juce.com
+
+Some code from ASIO examples:
+// Copyright (c) 2003-2011 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+Some code from Bitcoin:
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+Some code from Tom Wu:
+This software is covered under the following copyright:
+
+/*
+ * Copyright (c) 2003-2005  Tom Wu
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
+ * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
+ *
+ * IN NO EVENT SHALL TOM WU BE LIABLE FOR ANY SPECIAL, INCIDENTAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND, OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER OR NOT ADVISED OF
+ * THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF LIABILITY, ARISING OUT
+ * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * In addition, the following condition applies:
+ *
+ * All redistributions must retain an intact copy of this copyright notice
+ * and disclaimer.
+ */
+
+Address all questions regarding this license to:
+
+  Tom Wu
+  tjw@cs.Stanford.EDU

--- a/README.md
+++ b/README.md
@@ -1,3 +1,93 @@
-# ripple-sign-serialize
+# ripple-offline-tool
  
-Coming soon...
+[![CircleCI](https://circleci.com/gh/ximinez/ripple-offline-tool.svg?style=svg)](https://circleci.com/gh/ximinez/ripple-offline-tool)
+[![Build Status](https://travis-ci.org/ximinez/ripple-offline-tool.svg?branch=master)](https://travis-ci.org/ximinez/ripple-offline-tool)
+[![Build status](https://ci.appveyor.com/api/projects/status/ypsy8txb79ppe4g0?svg=true)](https://ci.appveyor.com/project/ximinez/ripple-offline-tool)
+[![codecov](https://codecov.io/gh/ximinez/ripple-offline-tool/branch/master/graph/badge.svg)](https://codecov.io/gh/ximinez/ripple-offline-tool)
+
+Rippled serialization and transaction signing command-line tool
+
+## Table of contents
+
+* [Dependencies](#dependencies)
+  * [ripple-libpp submodule](#ripple-libpp-submodule)
+  * [Other dependencies](#other-dependencies)
+* [Build and run](#build-and-run)
+* [Usage](#guide)
+  * [Key File Format](#key-file-format)
+
+## Dependencies
+
+### ripple-libpp submodule
+
+This includes a git submodule to the ripple-libpp source code, which is not cloned by default. To get the ripple-libpp source, either clone this repository using
+```
+$ git clone --recursive <location>
+```
+or after cloning, run the following commands
+```
+$ git submodule update --init --recursive
+```
+
+### Other dependencies
+
+* C++14 or greater
+* [Boost](http://www.boost.org/)
+* [OpenSSL](https://www.openssl.org/)
+* [cmake](https://cmake.org)
+
+## Build and run
+
+For linux and other unix-like OSes, run the following commands:
+
+```
+$ cd ${YOUR_RIPPLE_SERIALIZE_DIRECTORY}
+$ git submodule update --init --recursive  # if you haven't already
+$ mkdir -p build/gcc.debug
+$ cd build/gcc.debug
+$ cmake ../..
+$ cmake --build .
+$ ./ripple-offline-tool --unittest
+$ ./ripple-offline-tool --help
+```
+
+For 64-bit Windows, open a MSBuild Command Prompt for Visual Studio
+and run the following commands:
+
+```
+> cd %YOUR_RIPPLE_SERIALIZE_DIRECTORY%
+> git submodule update --init --recursive  # if you haven't already
+> mkdir build
+> cd build
+> cmake -G"Visual Studio 14 2015 Win64" ..
+> cmake --build .
+> .\Debug\ripple-offline-tool.exe --unittest
+> .\Debug\ripple-offline-tool.exe --help
+```
+
+32-bit Windows builds are not officially supported.
+
+# Usage
+
+Run `ripple-offline-tool --help` for usage information.
+
+## Key File Format
+
+The key file contains one JSON object. That object has a series of string
+name/value pairs. The only required fields are `key_type` and
+`master_seed`. Other fields are derived internally as needed. This
+simplifies manual keyfile creation for existing ripple accounts. Example:
+
+```
+{
+      "key_type" : "ed25519",
+      "master_seed" : "sPUTYOURSECRETKEYHERE"
+}
+```
+
+For user convenience, the `createkeyfile` operation will write a new keyfile
+containing the same fields returned by `rippled`'s `wallet_propose` RPC command
+plus `secret_key` and `secret_key_hex`. While not needed for signing operations,
+this allows the user to easily retrieve or confirm their `account_id` for later
+use. It also removes the risk of allowing a potentially untrusted server to
+generate a secret key.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,100 @@
+# Set environment variables.
+environment:
+  PYTHON: C:/Python27-x64
+
+  # We bundle up protoc.exe and only the parts of boost and openssl we need so
+  # that it's a small download. We also use appveyor's free cache, avoiding fees
+  # downloading from S3 each time. 
+  # TODO: script to create this package.
+  RIPPLED_DEPS_PATH: rippled_deps15.02
+  RIPPLED_DEPS_URL: https://ripple.github.io/Downloads/appveyor/%RIPPLED_DEPS_PATH%.zip
+
+  # Other dependencies we just download each time.
+  PIP_PATH: get-pip.py
+  PIP_URL: https://bootstrap.pypa.io/%PIP_PATH%
+  # The % in this URL messes up variable substition, so any updates will
+  # need to update both PYWIN32_PATH and PYWIN32_URL
+  PYWIN32_PATH: pywin32-220.win-amd64-py2.7.exe
+  PYWIN32_URL: https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win-amd64-py2.7.exe
+
+  # Scons honours these environment variables, setting the include/lib paths.
+  BOOST_ROOT: C:/%RIPPLED_DEPS_PATH%/boost
+  OPENSSL_ROOT: C:/%RIPPLED_DEPS_PATH%/openssl
+
+  matrix:
+  # This build works, but our current Appveyor config runs matrix builds
+  # sequentially, and the one build is already slow enough.
+  # - build: scons
+  #   target: msvc.debug
+  - build: cmake
+    target: msvc.debug
+    buildconfig: Debug
+
+os: Visual Studio 2015
+
+# At the end of each successful build we cache this directory.
+# https://www.appveyor.com/docs/build-cache/
+# Resulting archive should not exceed 100 MB.
+cache:
+  - 'C:\%RIPPLED_DEPS_PATH%'
+  - '%PIP_PATH%'
+  - '%PYWIN32_PATH%'
+
+# This means we'll download a zip of the branch we want, rather than the full
+# history.
+#shallow_clone: true
+
+install:
+  # We want easy_install, python and protoc.exe on PATH.
+  - SET PATH=%PYTHON%;%PYTHON%/Scripts;C:/%RIPPLED_DEPS_PATH%;%PATH%
+
+  # `ps` prefix means the command is executed by powershell.
+  - ps: |
+        if(-not(Test-Path $env:PYWIN32_PATH)) {
+          echo "Download from $env:PYWIN32_URL"
+          Start-FileDownload $env:PYWIN32_URL
+        }
+  - git submodule update --init --recursive
+  - extras/ripple-libpp/extras/rippled/bin/ci/windows/install-dependencies.bat ../../../..
+
+  # Download dependencies if appveyor didn't restore them from the cache.
+  # Use 7zip to unzip.
+  - ps: |
+        if (-not(Test-Path 'C:/$env:RIPPLED_DEPS_PATH')) {
+            echo "Download from $env:RIPPLED_DEPS_URL"
+            Start-FileDownload "$env:RIPPLED_DEPS_URL"
+            7z x "$($env:RIPPLED_DEPS_PATH).zip" -oC:\ -y > $null
+        }
+
+  # Newer DEPS include a versions file.
+  # Dump it so we can verify correct behavior.
+  - ps: |
+        if (Test-Path "C:/$env:RIPPLED_DEPS_PATH/versions.txt") {
+          cat "C:/$env:RIPPLED_DEPS_PATH/versions.txt"
+        }
+
+build_script:
+  # We set the environment variables needed to put compilers on the PATH.
+  - '"%VS140COMNTOOLS%../../VC/vcvarsall.bat" x86_amd64'
+  # Show which version of the compiler we are using.
+  - cl
+  - ps: |
+        # Build with cmake
+        cmake --version
+        $cmake_target="$($env:target).ci"
+        "$cmake_target"
+        New-Item -ItemType Directory -Force -Path "build/$cmake_target"
+        Push-Location "build/$cmake_target"
+        cmake -G"Visual Studio 14 2015 Win64" -Dtarget="$cmake_target" ../..
+        cmake --build . --config $env:buildconfig -- -m
+        Pop-Location
+
+after_build:
+  - ps: |
+        $exe="build/$cmake_target/$env:buildconfig/ripple-offline-tool"
+        "Exe is at $exe"
+
+test_script:
+  - ps: |
+        # Run the ripple-offline-tool unit tests
+        & $exe --unittest

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,38 @@
+machine:
+  services:
+    - docker
+  environment:
+    PATH: "/home/ubuntu/cmake-3.6.2-Linux-x86_64/bin:$PATH"
+dependencies:
+  pre:
+    - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
+    - echo "deb [arch=amd64 trusted=yes] https://test-mirrors.ripple.com/ubuntu/ trusty testing" | sudo tee /etc/apt/sources.list.d/ripple.list
+    - sudo apt-get update -qq
+    - sudo apt-get purge -qq libboost1.48-dev
+    - sudo apt-get install -qq libboost1.60-all-dev
+    - sudo apt-get install -qq clang-3.6 gcc-5 g++-5 libobjc-5-dev libgcc-5-dev libstdc++-5-dev libclang1-3.6 libgcc1 libgomp1 libstdc++6 scons protobuf-compiler libprotobuf-dev libssl-dev exuberant-ctags
+    - lsb_release -a
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 99
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 99
+    - sudo update-alternatives --force --install /usr/bin/clang clang /usr/bin/clang-3.6 99 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.6
+    - gcc --version
+    - clang --version
+    - clang++ --version
+  cache_directories:
+    - ~/cmake-3.6.2-Linux-x86_64
+  override:
+    - >
+      if [ ! -d ~/cmake-3.6.2-Linux-x86_64 ]; then
+        echo "No cache - building CMake"
+        cd ~ && wget --quiet https://cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz && tar -xvf cmake-3.6.2-Linux-x86_64.tar.gz
+      else
+        echo "Cached CMake found"
+      fi
+test:
+  pre:
+    - git submodule update --init --recursive
+    - mkdir -p build/gcc.debug
+    - cd build/gcc.debug && cmake ../.. && cmake --build .
+  override:
+    # Execute unit tests under gdb
+    - gdb -return-child-result -quiet -batch -ex "set env MALLOC_CHECK_=3" -ex "set print thread-events off" -ex run -ex "thread apply all backtrace full" -ex "quit" --args build/gcc.debug/ripple-offline-tool --unittest

--- a/src/OfflineTool.cpp
+++ b/src/OfflineTool.cpp
@@ -1,0 +1,513 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <OfflineTool.h>
+#include <RippleKey.h>
+#include <Serialize.h>
+#include <ripple/beast/core/SemanticVersion.h>
+#include <ripple/beast/unit_test.h>
+#include <beast/unit_test/dstream.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+
+//------------------------------------------------------------------------------
+char const* const versionString =
+
+    //--------------------------------------------------------------------------
+    //  The build version number. You must edit this for each release
+    //  and follow the format described at http://semver.org/
+    //
+        "0.1.0"
+
+#if defined(DEBUG) || defined(SANITIZER)
+       "+"
+#ifdef DEBUG
+        "DEBUG"
+#ifdef SANITIZER
+        "."
+#endif
+#endif
+
+#ifdef SANITIZER
+        BEAST_PP_STR1_(SANITIZER)
+#endif
+#endif
+
+    //--------------------------------------------------------------------------
+    ;
+
+static
+int
+runUnitTests ()
+{
+    using namespace beast::unit_test;
+    beast::unit_test::dstream dout{std::cout};
+    reporter r{dout};
+    bool const anyFailed = r.run_each(global_suites());
+    if(anyFailed)
+        return EXIT_FAILURE;    //LCOV_EXCL_LINE
+    return EXIT_SUCCESS;
+}
+
+int
+doSerialize(std::string const& data)
+{
+    auto const tx = [&]
+    {
+        auto const json = offline::parseJson(data);
+        return json ? offline::makeObject(json) : boost::none;
+    }();
+    if (!tx)
+    {
+        std::cerr << "Unable to serialize \"" << data << "\"" <<
+            std::endl;
+        return EXIT_FAILURE;
+    }
+
+    auto const result = offline::serialize(*tx);
+
+    std::cout << result << std::endl;
+    return EXIT_SUCCESS;
+}
+
+int
+doDeserialize(std::string const& data)
+{
+    auto const fail = [&]
+    {
+        std::cerr << "Unable to deserialize \"" << data << "\"" <<
+            std::endl;
+    };
+    try
+    {
+        auto const result = offline::deserialize(boost::trim_copy(data));
+
+        if (result)
+        {
+            std::cout << result->getJson(0).toStyledString() << std::endl;
+            return EXIT_SUCCESS;
+        }
+        else
+        {
+            fail();
+            std::cerr << "Is this valid serialized data?" << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+    catch (std::exception const& e)
+    {
+        fail();
+        std::cerr << "Is this valid serialized data?" << std::endl;
+        std::cerr << "\tDetail: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}
+
+int
+doSign(std::string const& data,
+    boost::filesystem::path const& keyFile,
+    std::function<void(offline::RippleKey const& key,
+        ripple::STTx& tx)> signingOp)
+{
+    using namespace offline;
+    auto const fail = [&]()
+    {
+        std::cerr << "Unable to sign \"" << data << "\"" << std::endl;
+    };
+    boost::optional<ripple::STTx> tx;
+    try
+    {
+        tx.emplace(make_sttx(boost::trim_copy(data)));
+    }
+    catch (std::exception const& e)
+    {
+        fail();
+        std::cerr << "Detail: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    try
+    {
+        BOOST_ASSERT(tx);
+        auto const rippleKey = RippleKey::make_RippleKey(keyFile);
+
+        signingOp(rippleKey, *tx);
+
+        std::cout << tx->getJson(0).toStyledString() << std::endl;
+        return EXIT_SUCCESS;
+    }
+    catch (std::exception const& e)
+    {
+        fail();
+        std::cerr << "Reason: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+}
+
+int
+doSingleSign(std::string const& data,
+    boost::filesystem::path const& keyFile)
+{
+    return doSign(data, keyFile, [](auto const& key, auto& tx)
+    {
+        key.singleSign(tx);
+    });
+}
+
+int
+doMultiSign(std::string const& data,
+    boost::filesystem::path const& keyFile)
+{
+    return doSign(data, keyFile, [](auto const& key, auto& tx)
+    {
+        key.multiSign(tx);
+    });
+}
+
+int
+doCreateKeyfile(boost::filesystem::path const& keyFile,
+    boost::optional<std::string> const& keytype,
+    boost::optional<std::string> const& seed)
+{
+    using namespace ripple;
+    using namespace offline;
+
+    if (exists(keyFile))
+        throw std::runtime_error(
+            "Refusing to overwrite existing key file: " +
+            keyFile.string());
+
+    auto const kt = keytype ?
+        boost::optional<KeyType>{keyTypeFromString(*keytype)} :
+        boost::none;
+    if (kt && *kt == KeyType::invalid)
+    {
+        std::cerr << "Invalid key type: \"" << *keytype << "\"" <<
+            std::endl;
+        return EXIT_FAILURE;
+    }
+
+    auto const key = RippleKey::make_RippleKey(kt, seed);
+
+    key.writeToFile(keyFile);
+
+    std::cout << "New ripple key created " <<
+        "in " << keyFile.string() << "\n" <<
+        "Key type is " << to_string(key.keyType()) << ", and " <<
+        "account ID is " <<
+        toBase58(calcAccountID(key.publicKey())) << "\n" <<
+        "\nThis file should be stored securely and not shared\n\n";
+
+    return EXIT_SUCCESS;
+}
+
+std::string
+getStdin()
+{
+    std::ostringstream stdinput;
+    stdinput << std::cin.rdbuf();
+    return stdinput.str();
+}
+
+int
+runCommand (const std::string& command,
+    std::vector <std::string> const& args,
+    boost::filesystem::path const& keyFile,
+    boost::optional<std::string> const& keyType,
+    InputType const& inputType)
+{
+    using namespace std;
+
+    struct commandParams
+    {
+        bool const allowNoInput;
+        std::function<int(boost::optional<std::string> const& input,
+            boost::filesystem::path const& keyFile,
+            boost::optional<std::string> const& keyType)> const action;
+    };
+    /* TODO: VC compiler doesn't like
+            std::function<void(std::string const& input)> const action;
+        with each of the lamdas capturing other local variables.
+    */
+    auto const serialize = [](
+        auto const& input, auto const&, auto const&)
+    {
+        BOOST_ASSERT(input);
+        return doSerialize(*input);
+    };
+    auto const deserialize = [](
+        auto const& input, auto const&, auto const&)
+    {
+        BOOST_ASSERT(input);
+        return doDeserialize(*input);
+    };
+    auto const sign = [](
+        auto const& input, auto const& keyFile, auto const&)
+    {
+        BOOST_ASSERT(input);
+        return doSingleSign(*input, keyFile);
+    };
+    auto const multisign = [](
+        auto const& input, auto const& keyFile, auto const&)
+    {
+        BOOST_ASSERT(input);
+        return doMultiSign(*input, keyFile);
+    };
+    auto const createkeyfile = [](
+        auto const& seed, auto const& keyFile, auto const& keyType)
+    {
+        return doCreateKeyfile(keyFile, keyType, seed);
+    };
+    auto const argumenterror = []()
+    {
+        throw std::runtime_error("Syntax error: Wrong number of arguments");
+    };
+    static map<string, commandParams>
+        const commandArgs = {
+            { "serialize", { false, serialize } },
+            { "deserialize", { false, deserialize } },
+            { "sign", { false, sign } },
+            { "multisign", { false, multisign } },
+            { "createkeyfile", { true, createkeyfile } },
+    };
+
+    auto const iArgs = commandArgs.find(command);
+
+    if (iArgs == commandArgs.end())
+        throw std::runtime_error("Unknown command: " + command);
+
+    // getInputType has already resolved conflicts
+    boost::optional<std::string> input;
+    switch (inputType)
+    {
+    case InputType::readstdin:
+        input = boost::trim_copy(getStdin());
+        break;
+
+    case InputType::commandline:
+        if (args.size() != 1)
+            argumenterror();
+        input = args[0];
+        break;
+
+    default:
+        if (! iArgs->second.allowNoInput)
+            argumenterror();
+        break;
+    }
+
+    BOOST_ASSERT(iArgs->second.action);
+    return iArgs->second.action(input, keyFile, keyType);
+}
+
+//LCOV_EXCL_START
+static
+std::string
+getEnvVar (char const* name)
+{
+    std::string value;
+
+    auto const v = getenv (name);
+
+    if (v != nullptr)
+        value = v;
+
+    return value;
+}
+
+void printHelp (const boost::program_options::options_description& desc,
+    boost::filesystem::path const& defaultKeyfile)
+{
+    static std::string const name = "ripple-offline-tool";
+
+    std::cerr
+        << name << " [options] <command> [<argument> ...]\n"
+        << desc << std::endl <<
+R"(Commands:
+  Serialization:
+    serialize <argument>|--stdin        Serialize from JSON.
+    deserialize <argument>|--stdin      Deserialize to JSON.
+  Transaction signing:
+    sign <argument>|--stdin             Sign for submission.
+    multisign <argument>|--stdin        Apply a multi-signature.
+      Signing commands require a valid keyfile.
+      Input is serialized or unserialized JSON.
+      Output is unserialized JSON.
+  Key Management:
+    createkeyfile [<key>|--stdin]       Create keyfile. A random
+      seed will be used if no <key> is provided on the command line
+      or from standard input using --stdin.
+
+      Default keyfile is: )" << defaultKeyfile << "\n";
+}
+
+InputType
+getInputType(boost::program_options::variables_map const& vm)
+{
+    namespace po = boost::program_options;
+
+    bool const readstdin = vm.count("stdin") && !vm["stdin"].defaulted();
+    bool const commandline = ! vm["arguments"].empty() &&
+        ! vm["arguments"].defaulted();
+
+    if (readstdin && commandline)
+        throw std::runtime_error(
+            "Conflicting inputs: May only specify one of \"--stdin\" "
+                "and command line parameters.");
+    if (readstdin)
+        return InputType::readstdin;
+    if (commandline)
+        return InputType::commandline;
+    return InputType::none;
+}
+//LCOV_EXCL_STOP
+
+std::string const&
+getVersionString ()
+{
+    static std::string const value = [] {
+        std::string const s = versionString;
+        beast::SemanticVersion v;
+        if (!v.parse (s) || v.print () != s)
+            throw std::logic_error (s + ": Bad version string"); //LCOV_EXCL_LINE
+        return s;
+    }();
+    return value;
+}
+
+int main (int argc, char** argv)
+{
+#if defined(__GNUC__) && !defined(__clang__)
+    auto constexpr gccver = (__GNUC__ * 100 * 100) +
+                            (__GNUC_MINOR__ * 100) +
+                            __GNUC_PATCHLEVEL__;
+
+    static_assert (gccver >= 50100,
+        "GCC version 5.1.0 or later is required to compile ripple-offline-tool.");
+#endif
+
+    static_assert (BOOST_VERSION >= 105700,
+        "Boost version 1.57 or later is required to compile ripple-offline-tool");
+
+    namespace po = boost::program_options;
+
+    po::variables_map vm;
+
+    // Set up option parsing.
+    //
+    po::options_description general ("General Options");
+    general.add_options ()
+    ("help,h", "Display this message.")
+    ("unittest,u", "Perform unit tests.")
+    ("version", "Display the build version.")
+    ("keyfile,f", po::value<std::string>(), "Specify the key file.")
+    ("stdin,i", "Read input (private key or argument) from stdin.")
+    ;
+
+    po::options_description key("Key File Creation Options");
+    key.add_options()
+    ("keytype,t", po::value<std::string>(),
+        "Valid keytypes are secp256k1 and ed25519. Default is secp256k1.")
+    ;
+
+    // Interpret positional arguments as --parameters.
+    po::options_description hidden("Hidden options");
+    hidden.add_options()
+    ("command", po::value< std::string > (), "Command.")
+    ("arguments",po::value< std::vector<std::string> > ()->default_value(
+        std::vector <std::string> (), "empty"), "Arguments.")
+    ;
+    po::positional_options_description p;
+    p.add ("command", 1).add ("arguments", -1);
+
+    po::options_description help_options;
+    help_options.add(general).add(key);
+    po::options_description cmdline_options;
+    cmdline_options.add(help_options).add(hidden);
+
+    // Parse options, if no error.
+    try
+    {
+        po::store (po::command_line_parser (argc, argv)
+            .options (cmdline_options)    // Parse options.
+            .positional (p)               // Remainder as --parameters.
+            .run (),
+            vm);
+        po::notify (vm);                  // Invoke option notify functions.
+    }
+    //LCOV_EXCL_START
+    catch (std::exception const&)
+    {
+        std::cerr << "ripple-offline-tool: Incorrect command line syntax." << std::endl;
+        std::cerr << "Use '--help' for a list of options." << std::endl;
+        return EXIT_FAILURE;
+    }
+    //LCOV_EXCL_STOP
+
+    // Run the unit tests if requested.
+    // The unit tests will exit the application with an appropriate return code.
+    if (vm.count ("unittest"))
+        return runUnitTests();
+
+    //LCOV_EXCL_START
+    if (vm.count("version"))
+    {
+        std::cout << "ripple-offline-tool version " <<
+            getVersionString() << std::endl;
+        return EXIT_SUCCESS;
+    }
+
+    boost::filesystem::path const homeDir = getEnvVar("HOME");
+    auto const defaultKeyfile =
+        (homeDir.empty() ?
+            boost::filesystem::current_path() : homeDir) /
+        ".ripple" / "secret-key.txt";
+
+    if (vm.count ("help") || ! vm.count ("command"))
+    {
+        printHelp (help_options, defaultKeyfile);
+        return EXIT_SUCCESS;
+    }
+
+    try
+    {
+        using namespace boost::filesystem;
+
+        path const keyFile = vm.count("keyfile") ?
+            vm["keyfile"].as<std::string>() :
+            defaultKeyfile;
+        auto const keyType = vm.count("keytype") ?
+            boost::optional<std::string>(vm["keytype"].as<std::string>()) :
+            boost::none;
+        auto const inputType = getInputType(vm);
+
+        return runCommand(
+            vm["command"].as<std::string>(),
+            vm["arguments"].as<std::vector<std::string>>(),
+            keyFile, keyType, inputType);
+    }
+    catch (std::exception const& e)
+    {
+        std::cerr << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+    //LCOV_EXCL_STOP
+}

--- a/src/OfflineTool.h
+++ b/src/OfflineTool.h
@@ -1,0 +1,66 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <boost/optional.hpp>
+#include <vector>
+
+namespace boost
+{
+namespace filesystem
+{
+class path;
+}
+}
+
+enum class InputType
+{
+    none = 0,
+    readstdin,
+    commandline
+};
+
+int
+doSerialize(std::string const& data);
+
+int
+doDeserialize(std::string const& data);
+
+int
+doSingleSign(std::string const& data,
+    boost::filesystem::path const& keyFile);
+
+int
+doMultiSign(std::string const& data,
+    boost::filesystem::path const& keyFile);
+
+int
+doCreateKeyfile(boost::filesystem::path const& keyFile,
+    boost::optional<std::string> const& keytype,
+    boost::optional<std::string> const& seed);
+
+int
+runCommand (const std::string& command,
+    std::vector <std::string> const& args,
+    boost::filesystem::path const& keyFile,
+    boost::optional<std::string> const& keyType,
+    InputType const& inputType);
+
+std::string const&
+getVersionString();

--- a/src/RippleKey.cpp
+++ b/src/RippleKey.cpp
@@ -1,0 +1,192 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of ripple-offline-tool:
+https://github.com/ximinez/ripple-offline-tool
+Copyright (c) 2017 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <RippleKey.h>
+#include <ripple/json/json_reader.h>
+#include <ripple/json/to_string.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/protocol/Sign.h>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+namespace offline {
+
+RippleKey::RippleKey(ripple::KeyType const& keyType,
+    ripple::Seed const& seed)
+    : keyType_(keyType)
+    , seed_(seed)
+{
+    using namespace ripple;
+    std::tie(publicKey_, secretKey_) = generateKeyPair(
+        keyType_, seed_);
+}
+
+RippleKey
+RippleKey::make_RippleKey(boost::optional<ripple::KeyType> const& keyType,
+    boost::optional<std::string> const& rawseed)
+{
+    if (keyType && rawseed)
+    {
+        auto const seed = ripple::parseGenericSeed(*rawseed);
+
+        if (!seed)
+            throw std::runtime_error(
+                "Unable to parse seed: " + *rawseed);
+
+        return RippleKey{ *keyType, *seed };
+    }
+    if (rawseed)
+        return RippleKey::make_RippleKey(RippleKey::defaultKeyType(),
+            *rawseed);
+    if (keyType)
+        return RippleKey{ *keyType };
+    return RippleKey{};
+}
+
+RippleKey
+RippleKey::make_RippleKey(
+    boost::filesystem::path const& keyFile)
+{
+    using namespace ripple;
+
+    std::ifstream ifsKeys (keyFile.string (), std::ios::in);
+
+    if (! ifsKeys)
+        throw std::runtime_error (
+            "Failed to open key file: " + keyFile.string());
+
+    Json::Reader reader;
+    Json::Value jKeys;
+    if (! reader.parse (ifsKeys, jKeys))
+    {
+        throw std::runtime_error (
+            "Unable to parse json key file: " + keyFile.string());
+    }
+
+    static std::array<Json::StaticString, 2> const requiredFields {{
+        jss::key_type,
+        jss::master_seed
+    }};
+
+    for (auto field : requiredFields)
+    {
+        if (! jKeys.isMember(field))
+        {
+            throw std::runtime_error (
+                std::string{ "Field '" } + field.c_str() +
+                "' is missing from key file: " +
+                keyFile.string());
+        }
+    }
+
+    auto const keyType = keyTypeFromString (jKeys[jss::key_type].asString());
+    if (keyType == KeyType::invalid)
+    {
+        throw std::runtime_error (
+            "Invalid 'key_type' field \"" +
+            jKeys[jss::key_type].asString() +
+            "\" found in key file: " +
+            keyFile.string());
+    }
+
+    return RippleKey::make_RippleKey (
+        keyType, jKeys[jss::master_seed].asString());
+}
+
+void
+RippleKey::writeToFile(boost::filesystem::path const& keyFile) const
+{
+    using namespace ripple;
+    using namespace boost::filesystem;
+
+    Json::Value jv(Json::objectValue);
+    jv[jss::key_type] = to_string(keyType_);
+    jv[jss::master_seed] = toBase58(seed_);
+    jv[jss::master_seed_hex] = strHex(seed_.data(), seed_.size());
+    jv[jss::master_key] = seedAs1751(seed_);
+    jv[jss::account_id] = toBase58(calcAccountID(publicKey_));
+    jv[jss::public_key] = toBase58(TOKEN_ACCOUNT_PUBLIC, publicKey_);
+    jv[jss::public_key_hex] = strHex(publicKey_.data(), publicKey_.size());
+    jv["secret_key"] = toBase58(TOKEN_ACCOUNT_SECRET, secretKey_);
+    jv["secret_key_hex"] = strHex(secretKey_.data(), secretKey_.size());
+
+    if (!keyFile.parent_path().empty())
+    {
+        boost::system::error_code ec;
+        if (!exists(keyFile.parent_path()))
+            boost::filesystem::create_directories(keyFile.parent_path(), ec);
+
+        if (ec || !is_directory(keyFile.parent_path()))
+            throw std::runtime_error("Cannot create directory: " +
+                keyFile.parent_path().string());
+    }
+
+    std::ofstream o(keyFile.string(), std::ios::trunc);
+    if (o.fail())
+        throw std::runtime_error("Cannot open key file: " +
+            keyFile.string());
+
+    o << jv.toStyledString();
+}
+
+void
+RippleKey::singleSign(ripple::STTx& tx) const
+{
+    using namespace ripple;
+    tx.setFieldVL(sfSigningPubKey, publicKey_.slice());
+    tx.makeFieldAbsent(sfSigners);
+    tx.sign(publicKey_, secretKey_);
+}
+
+void
+RippleKey::multiSign(ripple::STTx& tx) const
+{
+    using namespace ripple;
+    tx.setFieldVL(sfSigningPubKey, Slice{ nullptr, 0 });
+    tx.makeFieldAbsent(sfTxnSignature);
+
+    auto const accountID = calcAccountID(publicKey_);
+    Serializer s = buildMultiSigningData(tx, accountID);
+
+    auto const multisig = ripple::sign(
+        publicKey_, secretKey_, s.slice());
+
+    // Build an entry for this signer
+    STObject signer(sfSigner);
+    signer[sfAccount] = accountID;
+    signer[sfSigningPubKey] = publicKey_;
+    signer[sfTxnSignature] = multisig;
+
+    // Insert the signer into the array of signers
+    if (!tx.isFieldPresent(sfSigners))
+        tx.setFieldArray(sfSigners, {});
+    STArray& signers{ tx.peekFieldArray(sfSigners) };
+    signers.emplace_back(std::move(signer));
+
+    // Sort the Signers array by Account.  If it is not sorted when submitted
+    // to the network then it will be rejected.
+    std::sort (signers.begin(), signers.end(),
+        [](STObject const& a, STObject const& b)
+    {
+        return (a[sfAccount] < b[sfAccount]);
+    });
+}
+
+}   // serialize

--- a/src/RippleKey.h
+++ b/src/RippleKey.h
@@ -1,0 +1,124 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of ripple-offline-tool:
+https://github.com/ximinez/ripple-offline-tool
+Copyright (c) 2017 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/st.h>
+
+namespace boost
+{
+namespace filesystem
+{
+class path;
+}
+}
+
+namespace offline {
+
+class RippleKey
+{
+private:
+    static ripple::KeyType constexpr defaultKeyType()
+    {
+        return ripple::KeyType::secp256k1;
+    }
+    ripple::KeyType keyType_;
+    ripple::Seed seed_;
+    ripple::PublicKey publicKey_;
+    ripple::SecretKey secretKey_;
+
+public:
+    RippleKey()
+        : RippleKey(RippleKey::defaultKeyType())
+    {}
+
+    explicit
+    RippleKey(ripple::KeyType const& keyType)
+        : RippleKey(keyType, ripple::randomSeed())
+    {}
+
+
+    RippleKey(
+        ripple::KeyType const& keyType,
+        ripple::Seed const& seed);
+
+    /** Attempt to construct RippleKey with variable parameters
+
+        @param keyType Optional key type
+        @param rawseed Optional string containing the seed
+
+        @throws std::runtime_error if the `rawseed` is set and cannot
+            be parsed into a `Seed`
+    */
+    static
+    RippleKey
+    make_RippleKey(boost::optional<ripple::KeyType> const& keyType,
+        boost::optional<std::string> const& rawseed);
+
+    /** Returns RippleKey constructed from JSON file
+
+        @param keyFile Path to JSON key file
+
+        @throws std::runtime_error if file content is invalid
+    */
+    static
+    RippleKey
+    make_RippleKey(
+        boost::filesystem::path const& keyFile);
+
+    /** Write key to JSON file
+
+        @param keyFile Path to file to write
+
+        @note Overwrites existing key file
+
+        @throws std::runtime_error if unable to create parent directory
+            or write to the file.
+    */
+    void
+    writeToFile (boost::filesystem::path const& keyFile) const;
+
+    /** Signs a transaction with the key
+
+        @param tx Transaction to single sign
+    */
+    void
+    singleSign(ripple::STTx& tx) const;
+
+    /** Add a signer to the transaction with the key
+
+        @param tx Transaction to multi sign
+    */
+    void
+    multiSign(ripple::STTx& tx) const;
+
+    /// KeyType of this key
+    ripple::KeyType const&
+    keyType() const
+    {
+        return keyType_;
+    }
+
+    /// PublicKey of this key
+    ripple::PublicKey const&
+    publicKey () const
+    {
+        return publicKey_;
+    }
+};
+} // serialize

--- a/src/Serialize.cpp
+++ b/src/Serialize.cpp
@@ -1,0 +1,107 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <Serialize.h>
+#include <ripple/basics/StringUtilities.h>
+#include <ripple/json/json_reader.h>
+#include <ripple/json/to_string.h>
+#include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/Sign.h>
+#include <beast/core/detail/base64.hpp>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+namespace offline {
+
+Json::Value
+parseJson(std::string const& raw)
+{
+    using namespace ripple;
+
+    Json::Value jv;
+    Json::Reader{}.parse(raw, jv);
+
+    return jv;
+}
+
+boost::optional<ripple::STObject>
+makeObject(Json::Value const& json)
+{
+    using namespace ripple;
+
+    STParsedJSONObject parsed("", json);
+
+    return parsed.object;
+}
+
+std::string
+serialize(ripple::STObject const& object)
+{
+    using namespace ripple;
+
+    return strHex(object.getSerializer().peekData());
+}
+
+boost::optional<ripple::STObject>
+deserialize(std::string const& blob)
+{
+    using namespace ripple;
+
+    auto const unhex{ strUnHex(blob) };
+
+    if (!unhex.second || !unhex.first.size())
+        return{};
+
+    SerialIter sitTrans{ makeSlice(unhex.first) };
+    // Can Throw
+    return STObject{ std::ref(sitTrans), sfGeneric };
+}
+
+ripple::STTx
+make_sttx(std::string const& data)
+{
+    boost::optional<ripple::STObject> obj;
+    try
+    {
+        obj = deserialize(data);
+    }
+    catch (std::exception const& e)
+    {
+        auto msg = std::string{ "unable to deserialize (internal: " }
+            + e.what() + ")";
+        throw std::runtime_error(msg);
+    }
+    if (!obj)
+    {
+        auto const json = offline::parseJson(data);
+        if (json)
+            obj = offline::makeObject(json);
+        else
+            throw std::runtime_error("invalid JSON");
+    }
+
+    using namespace ripple;
+
+    obj->makeFieldPresent(sfSigningPubKey);
+    // Can Throw
+    return STTx{ std::move(*obj) };
+}
+
+} // serialize

--- a/src/Serialize.h
+++ b/src/Serialize.h
@@ -1,0 +1,50 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/crypto/KeyType.h>
+#include <ripple/protocol/SecretKey.h>
+#include <ripple/protocol/st.h>
+
+namespace boost
+{
+namespace filesystem
+{
+class path;
+}
+}
+
+namespace offline {
+
+Json::Value
+parseJson(std::string const& json);
+
+boost::optional<ripple::STObject>
+makeObject(Json::Value const& json);
+
+std::string
+serialize(ripple::STObject const& tx);
+
+boost::optional<ripple::STObject>
+deserialize(std::string const& blob);
+
+ripple::STTx
+make_sttx(std::string const& data);
+
+} // serialize

--- a/src/test/KeyFileGuard.h
+++ b/src/test/KeyFileGuard.h
@@ -1,0 +1,82 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+namespace offline {
+
+namespace test {
+
+/**
+   Write a key file dir and remove when done.
+ */
+class KeyFileGuard
+{
+private:
+    using path = boost::filesystem::path;
+    path subDir_;
+    beast::unit_test::suite& test_;
+
+    auto rmDir (path const& toRm)
+    {
+        if (is_directory (toRm))
+            remove_all (toRm);
+        else
+            test_.log << "Expected " << toRm.string ()
+                      << " to be an existing directory." << std::endl;
+    };
+
+public:
+    KeyFileGuard (beast::unit_test::suite& test,
+        std::string const& subDir)
+        : subDir_ (subDir)
+        , test_ (test)
+    {
+        using namespace boost::filesystem;
+
+        if (!exists (subDir_))
+            create_directory (subDir_);
+        else
+            // Cannot run the test. Someone created a file or directory
+            // where we want to put our directory
+            throw std::runtime_error (
+                "Cannot create directory: " + subDir_.string ());
+    }
+    ~KeyFileGuard ()
+    {
+        try
+        {
+            using namespace boost::filesystem;
+
+            rmDir (subDir_);
+        }
+        catch (std::exception& e)
+        {
+            // if we throw here, just let it die.
+            test_.log << "Error in ~KeyFileGuard: " << e.what () << std::endl;
+        };
+    }
+};
+
+} // test
+
+}  // serialize

--- a/src/test/KnownTestData.h
+++ b/src/test/KnownTestData.h
@@ -1,0 +1,272 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef SERIALIZE_TESTS_KNOWNTX_H_INCLUDED
+#define SERIALIZE_TESTS_KNOWNTX_H_INCLUDED
+
+#include <string>
+
+namespace offline
+{
+namespace test
+{
+
+struct TestItem
+{
+    std::string JsonText;
+    std::string SerializedText;
+};
+
+inline
+TestItem
+const& getKnownTxSigned()
+{
+    // From the ripplelibppdemo output
+    static TestItem testTx
+    {
+        R"({
+            "Account" : "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn",
+            "Amount" :
+            {
+                    "currency" : "USD",
+                    "issuer" : "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                    "value" : "123400000"
+            },
+            "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+            "Fee" : "100",
+            "Flags" : 2147483648,
+            "SendMax" :
+            {
+                    "currency" : "CNY",
+                    "issuer" : "razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA",
+                    "value" : "5678900000000000e-4"
+            },
+            "Sequence" : 18,
+            "SigningPubKey" : "0388935426E0D08083314842EDFBB2D517BD47699F9A4527318A8E10468C97C052",
+            "TransactionType" : "Payment",
+            "TxnSignature" : "3044022030425DB6A46B5B57BDA85E5B8455B90DC4EC57BA1A707AF0C28DC9383E09643D0220195B9FDBE383B813A539F3B70E130482E92D1E1210B0F85551E11B3F81EB98BB",
+            "hash" : "F2D008D2AABBABD2A882F9049AA873210908EC3EA1EB0A2044A66093C7ACD2B1"
+            })",
+        "1200002280000000240000001261D684625103A72000000"
+        "00000000000000000000055534400000000002ADB0B3959D60A6E6991F729"
+        "E1918B716392523068400000000000006469D7542CEDF1370800000000000"
+        "000000000000000434E59000000000041C8BE2C0A6AA17471B9F6D0AF92AA"
+        "B1C94D5A2573210388935426E0D08083314842EDFBB2D517BD47699F9A452"
+        "7318A8E10468C97C05274463044022030425DB6A46B5B57BDA85E5B8455B9"
+        "0DC4EC57BA1A707AF0C28DC9383E09643D0220195B9FDBE383B813A539F3B"
+        "70E130482E92D1E1210B0F85551E11B3F81EB98BB8114AE123A8556F3CF91"
+        "154711376AFB0F894F832B3D8314B5F762798A53D543A014CAF8B297CFF8F"
+        "2F937E8"
+    };
+    return testTx;
+}
+
+inline
+TestItem
+const& getKnownTxUnsigned()
+{
+    // From the ripplelibppdemo output
+    static TestItem testTx
+    {
+        R"({
+           "Account" : "r9mC1zjD9u5SJXw56pdPhxoDSHaiNcisET",
+           "Amount" : {
+              "currency" : "USD",
+              "issuer" : "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+              "value" : "123400000"
+           },
+           "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+           "Fee" : "100",
+           "Flags" : 2147483648,
+           "SendMax" : {
+              "currency" : "CNY",
+              "issuer" : "razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA",
+              "value" : "5678900000000000e-4"
+           },
+           "Sequence" : 18,
+           "TransactionType" : "Payment",
+            })",
+        "1200002280000000240000001261D684625103A72000000000000000000000"
+        "00000055534400000000002ADB0B3959D60A6E6991F729E1918B7163925230"
+        "68400000000000006469D7542CEDF137080000000000000000000000000043"
+        "4E59000000000041C8BE2C0A6AA17471B9F6D0AF92AAB1C94D5A2581146033"
+        "C369F0723DAE44A22957D7EF492CC5F80A2D8314B5F762798A53D543A014CA"
+        "F8B297CFF8F2F937E8"
+    };
+    return testTx;
+}
+
+inline
+TestItem
+const& getKnownMetadata()
+{
+    // From tx FC8CB8BFE0BEE91BCC39BBB31827230BEDF273C300EC2F6DB212A31CA9CE7E94
+    // in ledger 28812538 (chosen arbitrarily)
+    static TestItem testMeta{
+        R"({
+            "AffectedNodes" : [
+                {
+                "CreatedNode" : {
+                    "LedgerEntryType" : "Offer",
+                    "LedgerIndex" : "7EAEE1B418DC7C00FC41E8DE6BA4FC0D79CD6F7476D44B3D99B2346F3A78FE96",
+                    "NewFields" : {
+                        "Account" : "rH3uSRUJYoJhK4kL9x1mzUhDimKE2n3oT6",
+                        "BookDirectory" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3BAC8E0468B",
+                        "OwnerNode" : "00000000000000FB",
+                        "Sequence" : 4330215,
+                        "TakerGets" : "80000000000",
+                        "TakerPays" : {
+                            "currency" : "EUR",
+                            "issuer" : "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                            "value" : "2902.472875273122"
+                        }
+                    }
+                }
+                },
+                {
+                "DeletedNode" : {
+                    "FinalFields" : {
+                        "Account" : "rH3uSRUJYoJhK4kL9x1mzUhDimKE2n3oT6",
+                        "BookDirectory" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3CBADF66AFE",
+                        "BookNode" : "0000000000000000",
+                        "Flags" : 0,
+                        "OwnerNode" : "00000000000000FB",
+                        "PreviousTxnID" : "70F1E60F21B2A49ECBFE2D19E2867E28D7C8F210E111A58F1C68541F71FBCFE3",
+                        "PreviousTxnLgrSeq" : 28812537,
+                        "Sequence" : 4330209,
+                        "TakerGets" : "80000000000",
+                        "TakerPays" : {
+                            "currency" : "EUR",
+                            "issuer" : "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+                            "value" : "2902.530925601381"
+                        }
+                    },
+                    "LedgerEntryType" : "Offer",
+                    "LedgerIndex" : "8C2BEAAC384B373313F4E3E736A1C933B40E1AACB9D78B9F363BBF6D9A4CCA60"
+                }
+                },
+                {
+                "ModifiedNode" : {
+                    "FinalFields" : {
+                        "Account" : "rH3uSRUJYoJhK4kL9x1mzUhDimKE2n3oT6",
+                        "Balance" : "104439515445",
+                        "Flags" : 0,
+                        "OwnerCount" : 23,
+                        "Sequence" : 4330216
+                    },
+                    "LedgerEntryType" : "AccountRoot",
+                    "LedgerIndex" : "94BAA26006FDE92FFDFD1EBBD162F38532C411004A04842C9DAC0E37FF24F371",
+                    "PreviousFields" : {
+                        "Balance" : "104439515731",
+                        "Sequence" : 4330215
+                    },
+                    "PreviousTxnID" : "9CD12991D25C792CA14DE4FAFCA1E55A59CA82BA7F1E045BCC212807CCBCC928",
+                    "PreviousTxnLgrSeq" : 28812537
+                }
+                },
+                {
+                "ModifiedNode" : {
+                    "FinalFields" : {
+                        "Flags" : 0,
+                        "IndexPrevious" : "0000000000000000",
+                        "Owner" : "rH3uSRUJYoJhK4kL9x1mzUhDimKE2n3oT6",
+                        "RootIndex" : "FF060B902D93027D3C91161AB9534D1144ABAA309C2FD848783F5A3B9A11A80C"
+                    },
+                    "LedgerEntryType" : "DirectoryNode",
+                    "LedgerIndex" : "A283077E7F53AEBE1EBE2FA6A5302C0594B34B6B6C04CB4972678B46F688756A"
+                }
+                },
+                {
+                "ModifiedNode" : {
+                    "FinalFields" : {
+                        "ExchangeRate" : "4D0CE3BAC8E0468B",
+                        "Flags" : 0,
+                        "RootIndex" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3BAC8E0468B",
+                        "TakerGetsCurrency" : "0000000000000000000000000000000000000000",
+                        "TakerGetsIssuer" : "0000000000000000000000000000000000000000",
+                        "TakerPaysCurrency" : "0000000000000000000000004555520000000000",
+                        "TakerPaysIssuer" : "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                    },
+                    "LedgerEntryType" : "DirectoryNode",
+                    "LedgerIndex" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3BAC8E0468B"
+                }
+                },
+                {
+                "DeletedNode" : {
+                    "FinalFields" : {
+                        "ExchangeRate" : "4D0CE3CBADF66AFE",
+                        "Flags" : 0,
+                        "RootIndex" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3CBADF66AFE",
+                        "TakerGetsCurrency" : "0000000000000000000000000000000000000000",
+                        "TakerGetsIssuer" : "0000000000000000000000000000000000000000",
+                        "TakerPaysCurrency" : "0000000000000000000000004555520000000000",
+                        "TakerPaysIssuer" : "2ADB0B3959D60A6E6991F729E1918B7163925230"
+                    },
+                    "LedgerEntryType" : "DirectoryNode",
+                    "LedgerIndex" : "BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3CBADF66AFE"
+                }
+                }
+            ],
+            "TransactionIndex" : 21,
+            "TransactionResult" : "tesSUCCESS"
+        })",
+        "201C00000015F8E311006F567EAEE1B418DC7C00FC41E8DE6BA4FC0D79"
+        "CD6F7476D44B3D99B2346F3A78FE96E824004212E73400000000000000"
+        "FB5010BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0C"
+        "E3BAC8E0468B64D54A4FC8A0B36BA20000000000000000000000004555"
+        "5200000000002ADB0B3959D60A6E6991F729E1918B7163925230654000"
+        "0012A05F20008114B100B28F60C3A425467387913CC0B297D3DA702CE1"
+        "E1E411006F568C2BEAAC384B373313F4E3E736A1C933B40E1AACB9D78B"
+        "9F363BBF6D9A4CCA60E7220000000024004212E12501B7A4F933000000"
+        "00000000003400000000000000FB5570F1E60F21B2A49ECBFE2D19E286"
+        "7E28D7C8F210E111A58F1C68541F71FBCFE35010BC05A0B94DB6C7C0B2"
+        "D9E04573F0463DC15DB8033ABA85624D0CE3CBADF66AFE64D54A4FD624"
+        "C5226500000000000000000000000045555200000000002ADB0B3959D6"
+        "0A6E6991F729E1918B71639252306540000012A05F20008114B100B28F"
+        "60C3A425467387913CC0B297D3DA702CE1E1E51100612501B7A4F9559C"
+        "D12991D25C792CA14DE4FAFCA1E55A59CA82BA7F1E045BCC212807CCBC"
+        "C9285694BAA26006FDE92FFDFD1EBBD162F38532C411004A04842C9DAC"
+        "0E37FF24F371E624004212E7624000001851148A53E1E7220000000024"
+        "004212E82D000000176240000018511489358114B100B28F60C3A42546"
+        "7387913CC0B297D3DA702CE1E1E511006456A283077E7F53AEBE1EBE2F"
+        "A6A5302C0594B34B6B6C04CB4972678B46F688756AE722000000003200"
+        "0000000000000058FF060B902D93027D3C91161AB9534D1144ABAA309C"
+        "2FD848783F5A3B9A11A80C8214B100B28F60C3A425467387913CC0B297"
+        "D3DA702CE1E1E511006456BC05A0B94DB6C7C0B2D9E04573F0463DC15D"
+        "B8033ABA85624D0CE3BAC8E0468BE72200000000364D0CE3BAC8E0468B"
+        "58BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3BA"
+        "C8E0468B0111000000000000000000000000455552000000000002112A"
+        "DB0B3959D60A6E6991F729E1918B716392523003110000000000000000"
+        "0000000000000000000000000411000000000000000000000000000000"
+        "0000000000E1E1E411006456BC05A0B94DB6C7C0B2D9E04573F0463DC1"
+        "5DB8033ABA85624D0CE3CBADF66AFEE72200000000364D0CE3CBADF66A"
+        "FE58BC05A0B94DB6C7C0B2D9E04573F0463DC15DB8033ABA85624D0CE3"
+        "CBADF66AFE011100000000000000000000000045555200000000000211"
+        "2ADB0B3959D60A6E6991F729E1918B7163925230031100000000000000"
+        "0000000000000000000000000004110000000000000000000000000000"
+        "000000000000E1E1F1031000"
+    };
+    return testMeta;
+}
+
+} // test
+} // serialize
+
+#endif // !SERIALIZE_TESTS_KNOWNTX_H_INCLUDED

--- a/src/test/OfflineTool_test.cpp
+++ b/src/test/OfflineTool_test.cpp
@@ -1,0 +1,689 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <OfflineTool.h>
+#include <RippleKey.h>
+#include <Serialize.h>
+#include <test/KnownTestData.h>
+#include <test/KeyFileGuard.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/SecretKey.h>
+#include <boost/format.hpp>
+
+namespace offline {
+
+namespace test {
+
+class OfflineTool_test : public beast::unit_test::suite
+{
+private:
+
+    // Allow cout and cerr to be redirected to a buffer.
+    // Destructor restores old cout and cerr streambufs.
+    class CoutRedirect
+    {
+    public:
+        CoutRedirect()
+            : oldOut_(std::cout.rdbuf(captureOut.rdbuf()))
+            , oldErr_(std::cerr.rdbuf(captureErr.rdbuf()))
+        {
+        }
+
+        ~CoutRedirect()
+        {
+            std::cout.rdbuf(oldOut_);
+            std::cerr.rdbuf(oldErr_);
+        }
+
+        std::string out() const
+        {
+            return captureOut.str();
+        }
+
+        std::string err() const
+        {
+            return captureErr.str();
+        }
+
+    private:
+        std::stringstream captureOut;
+        std::stringstream captureErr;
+
+        std::streambuf* const oldOut_;
+        std::streambuf* const oldErr_;
+    };
+
+    class CInRedirect
+    {
+    public:
+        CInRedirect(std::stringstream const& sStream)
+            : old_(std::cin.rdbuf(sStream.rdbuf()))
+        {
+        }
+
+        ~CInRedirect()
+        {
+            std::cin.rdbuf(old_);
+        }
+
+    private:
+        std::streambuf* const old_;
+    };
+
+    void
+    testSerialize()
+    {
+        testcase("Serialize");
+
+        auto test = [&](TestItem const& testItem)
+        {
+            {
+                CoutRedirect coutRedirect;
+
+                auto const exit = doSerialize(testItem.JsonText);
+
+                BEAST_EXPECT(exit == EXIT_SUCCESS);
+                BEAST_EXPECT(coutRedirect.out() == testItem.SerializedText + "\n");
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+            }
+            {
+                std::stringstream jsoninput(testItem.JsonText);
+                CInRedirect cinRedirect{ jsoninput };
+                CoutRedirect coutRedirect;
+
+                auto const exit = runCommand("serialize", {}, {}, {},
+                    InputType::readstdin);
+
+                BEAST_EXPECT(exit == EXIT_SUCCESS);
+                BEAST_EXPECT(coutRedirect.out() == testItem.SerializedText + "\n");
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+            }
+        };
+
+        test(getKnownTxSigned());
+        test(getKnownTxUnsigned());
+        test(getKnownMetadata());
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it nonsense
+            auto const exit = doSerialize("Hello, world!");
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECT(coutRedirect.out().empty());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to serialize \"Hello, world!\"\n");
+        };
+
+    }
+
+    void
+    testDeserialize()
+    {
+        testcase("Deserialize");
+
+        auto test = [&](TestItem const& testItem,
+            std::function<std::string(std::string)> modifySerialized = nullptr,
+            std::function<void(Json::Value&)> modifyKnownJson = nullptr)
+        {
+            {
+                CoutRedirect coutRedirect;
+
+                try
+                {
+                    auto const exit = doDeserialize(modifySerialized ?
+                        modifySerialized(testItem.SerializedText) :
+                        testItem.SerializedText);
+                    BEAST_EXPECT(exit == EXIT_SUCCESS);
+                }
+                catch (...)
+                {
+                    fail();
+                }
+
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                auto const captured = parseJson(coutRedirect.out());
+                auto known = parseJson(testItem.JsonText);
+                if (modifyKnownJson)
+                    modifyKnownJson(known);
+                BEAST_EXPECT(captured == known);
+            }
+            {
+                std::stringstream serinput(modifySerialized ?
+                    modifySerialized(testItem.SerializedText) :
+                    testItem.SerializedText);
+                CInRedirect cinRedirect{ serinput };
+
+                CoutRedirect coutRedirect;
+
+                auto const exit = runCommand("deserialize", {}, {}, {}, InputType::readstdin);
+
+                BEAST_EXPECT(exit == EXIT_SUCCESS);
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                auto const captured = parseJson(coutRedirect.out());
+                auto known = parseJson(testItem.JsonText);
+                if (modifyKnownJson)
+                    modifyKnownJson(known);
+                BEAST_EXPECT(captured == known);
+            }
+        };
+        test(getKnownTxSigned(),
+            [](auto serialized)
+            {
+                // include some extra whitespace, since deserialization
+                // is sensitive to that.
+                return "  " + serialized + "\n\n";
+            },
+            [](auto& known)
+            {
+                // The hash field is STTx-specific (and computed),
+                // so it won't be in the generic output.
+                known.removeMember("hash");
+            });
+        test(getKnownTxUnsigned());
+        test(getKnownMetadata());
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it nonsense
+            auto const exit = doDeserialize("Hello, world!");
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to deserialize \"Hello, world!\"\n"
+                "Is this valid serialized data?\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it an incomplete Tx
+            auto shortTx = getKnownTxUnsigned().SerializedText.substr(0, 192);
+            auto const exit = doDeserialize(shortTx);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to deserialize \"" + shortTx + "\"\n"
+                "Is this valid serialized data?\n"
+                "\tDetail: invalid SerialIter getBitString\n");
+        }
+    }
+
+    void
+    testSingleSign()
+    {
+        testcase("Single Sign");
+
+        using namespace boost::filesystem;
+
+        std::string const subdir = "test_key_file";
+        KeyFileGuard g(*this, subdir);
+        path const keyFile = subdir / ".ripple" / "secret-key.txt";
+
+        {
+            RippleKey const key;
+            key.writeToFile(keyFile);
+        }
+
+        auto const& knownTx = getKnownTxSigned();
+        auto const origTx = offline::deserialize(knownTx.SerializedText);
+
+        auto test = [&](std::string const& testData)
+        {
+            using namespace ripple;
+
+            auto go = [&](std::string const& json)
+            {
+                auto const tx = make_sttx(json);
+                BEAST_EXPECT(tx.checkSign(true).first);
+                BEAST_EXPECT(tx[sfSigningPubKey] !=
+                    (*origTx)[sfSigningPubKey]);
+                BEAST_EXPECT(tx[sfTxnSignature] !=
+                    (*origTx)[sfTxnSignature]);
+                BEAST_EXPECT(!tx.isFieldPresent(sfSigners));
+            };
+            {
+                CoutRedirect coutRedirect;
+
+                try
+                {
+                    auto const exit = doSingleSign(testData, keyFile);
+                    BEAST_EXPECT(exit == EXIT_SUCCESS);
+                }
+                catch (...)
+                {
+                    fail();
+                    return;
+                }
+
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                go(coutRedirect.out());
+            }
+            {
+                std::stringstream serinput(testData);
+                CInRedirect cinRedirect{ serinput };
+                CoutRedirect coutRedirect;
+
+                auto const exit = runCommand("sign", {}, keyFile, {},
+                    InputType::readstdin);
+
+                BEAST_EXPECT(exit == EXIT_SUCCESS);
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                go(coutRedirect.out());
+            }
+        };
+        test(knownTx.SerializedText);
+        test(knownTx.JsonText);
+        auto const& knownTxUnsigned = getKnownTxUnsigned();
+        test(knownTxUnsigned.SerializedText);
+        test(knownTxUnsigned.JsonText);
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it nonsense
+            auto const exit = doSingleSign("Hello, world!", keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"Hello, world!\"\n"
+                "Detail: invalid JSON\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it an incomplete Tx
+            auto shortTx = getKnownTxUnsigned().SerializedText.substr(0, 192);
+            auto const exit = doSingleSign(shortTx, keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + shortTx + "\"\n"
+                "Detail: unable to deserialize (internal: invalid SerialIter getBitString)\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it a Tx with missing field
+            auto json = offline::parseJson(knownTxUnsigned.JsonText);
+            BEAST_EXPECT(json && json.isObject());
+            json.removeMember("Sequence");
+            auto const shortTx = json.toStyledString();
+            auto const exit = doSingleSign(shortTx, keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + shortTx + "\"\n"
+                "Detail: transaction not valid\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Use an invalid key file
+            auto const badKeyFile = subdir / "invalid.txt";
+            auto const exit = doSingleSign(knownTx.SerializedText,
+                badKeyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + knownTx.SerializedText + "\"\n"
+                "Reason: Failed to open key file: " +
+                badKeyFile.string() + "\n");
+        }
+    }
+
+    void
+    testMultiSign()
+    {
+        testcase("Multi Sign");
+
+        using namespace boost::filesystem;
+
+        std::string const subdir = "test_key_file";
+        KeyFileGuard g(*this, subdir);
+        path const keyFile = subdir / ".ripple" / "secret-key.txt";
+
+        {
+            RippleKey const key;
+            key.writeToFile(keyFile);
+        }
+
+        auto test = [&](std::string const& testData)
+        {
+            using namespace ripple;
+            {
+                CoutRedirect coutRedirect;
+
+                try
+                {
+                    auto const exit = doMultiSign(testData, keyFile);
+
+                    BEAST_EXPECT(exit == EXIT_SUCCESS);
+                    BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                    auto const tx = make_sttx(coutRedirect.out());
+                    BEAST_EXPECT(tx.checkSign(true).first);
+                    BEAST_EXPECT(tx.isFieldPresent(sfSigningPubKey));
+                    BEAST_EXPECT(tx[sfSigningPubKey].empty());
+                    BEAST_EXPECT(!tx.isFieldPresent(sfTxnSignature));
+                    BEAST_EXPECT(tx.isFieldPresent(sfSigners));
+                }
+                catch (...)
+                {
+                    fail();
+                }
+            }
+            {
+                std::stringstream serinput(testData);
+                CInRedirect cinRedirect{ serinput };
+                CoutRedirect coutRedirect;
+
+                auto const exit = runCommand("multisign", {}, keyFile, {},
+                    InputType::readstdin);
+
+                BEAST_EXPECT(exit == EXIT_SUCCESS);
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                auto const tx = make_sttx(coutRedirect.out());
+                BEAST_EXPECT(tx.checkSign(true).first);
+                BEAST_EXPECT(tx.isFieldPresent(sfSigningPubKey));
+                BEAST_EXPECT(tx[sfSigningPubKey].empty());
+                BEAST_EXPECT(!tx.isFieldPresent(sfTxnSignature));
+                BEAST_EXPECT(tx.isFieldPresent(sfSigners));
+            }
+        };
+        auto const& knownTxSigned = getKnownTxSigned();
+        test(knownTxSigned.SerializedText);
+        test(knownTxSigned.JsonText);
+        auto const& knownTxUnsigned = getKnownTxUnsigned();
+        test(knownTxUnsigned.SerializedText);
+        test(knownTxUnsigned.JsonText);
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it nonsense
+            auto const exit = doMultiSign("Hello, world!", keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"Hello, world!\"\n"
+                "Detail: invalid JSON\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it an incomplete Tx
+            auto shortTx = getKnownTxUnsigned().SerializedText.substr(0, 192);
+            auto const exit = doMultiSign(shortTx, keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + shortTx + "\"\n"
+                "Detail: unable to deserialize (internal: invalid SerialIter getBitString)\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Send it a Tx with missing field
+            auto json = offline::parseJson(knownTxUnsigned.JsonText);
+            BEAST_EXPECT(json && json.isObject());
+            json.removeMember("Sequence");
+            auto const shortTx = json.toStyledString();
+            auto const exit = doSingleSign(shortTx, keyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + shortTx + "\"\n"
+                "Detail: transaction not valid\n");
+        }
+        {
+            CoutRedirect coutRedirect;
+
+            // Use an invalid key file
+            auto const badKeyFile = subdir / "invalid.txt";
+            auto const exit = doMultiSign(knownTxUnsigned.SerializedText,
+                badKeyFile);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() ==
+                "Unable to sign \"" + knownTxUnsigned.SerializedText + "\"\n"
+                "Reason: Failed to open key file: " +
+                badKeyFile.string() + "\n");
+        }
+    }
+
+    void testCreateKeyfile()
+    {
+        testcase("Create keyfile");
+
+        using namespace boost::filesystem;
+        using namespace ripple;
+
+        std::string const subdir = "test_key_file";
+        KeyFileGuard g(*this, subdir);
+        path const keyFile = subdir / ".ripple" / "secret-key.txt";
+
+        auto test = [&](boost::optional<std::string> const& kt,
+            boost::optional<std::string> const& seed)
+        {
+            auto const go = [&](bool useCommand)
+            {
+                CoutRedirect coutRedirect;
+
+                if (useCommand)
+                {
+                    std::vector<std::string> args;
+                    InputType inputType = InputType::none;
+                    if (seed)
+                    {
+                        args.push_back(*seed);
+                        inputType = InputType::commandline;
+                    }
+                    auto const exit = runCommand("createkeyfile", args,
+                        keyFile, kt, inputType);
+                    BEAST_EXPECT(exit == EXIT_SUCCESS);
+                }
+                else
+                {
+                    auto const exit = doCreateKeyfile(keyFile, kt, seed);
+                    BEAST_EXPECT(exit == EXIT_SUCCESS);
+                }
+
+                auto const key = RippleKey::make_RippleKey(keyFile);
+
+                auto const known = boost::str(
+                    boost::format("New ripple key created in %s\n"
+                    "Key type is %s, and account ID is %s\n"
+                    "\nThis file should be stored securely and not shared\n\n")
+                    % keyFile.string()
+                    % to_string(key.keyType())
+                    % toBase58(calcAccountID(key.publicKey())));
+
+                // Test that the function will not overwrite
+                try
+                {
+                    if (useCommand)
+                        runCommand("createkeyfile", {}, keyFile, {}, {});
+                    else
+                        doCreateKeyfile(keyFile, {}, {});
+                    fail();
+                }
+                catch (std::exception const& e)
+                {
+                    BEAST_EXPECT(e.what() ==
+                        std::string{ "Refusing to overwrite existing key file: " +
+                        keyFile.string()});
+                }
+
+                remove(keyFile);
+
+                BEAST_EXPECTS(coutRedirect.err().empty(), coutRedirect.err());
+                BEAST_EXPECT(coutRedirect.out() == known);
+            };
+            go(false);
+            go(true);
+        };
+
+        test(boost::none, boost::none);
+        test(boost::none, std::string{ "masterpassphrase" });
+        test(std::string(to_string(KeyType::ed25519)), boost::none);
+        test(std::string(to_string(KeyType::secp256k1)),
+            std::string{ "alice" });
+
+        // edge cases
+        {
+            // invalid keytype
+            CoutRedirect coutRedirect;
+
+            auto const exit = doCreateKeyfile(keyFile,
+                std::string{ "NSA special" }, boost::none);
+
+            BEAST_EXPECT(exit == EXIT_FAILURE);
+            BEAST_EXPECT(!exists(keyFile));
+            BEAST_EXPECTS(coutRedirect.out().empty(), coutRedirect.out());
+            BEAST_EXPECT(coutRedirect.err() == "Invalid key type: \"NSA special\"\n");
+        }
+        {
+            // empty seed
+            try
+            {
+                doCreateKeyfile(keyFile, std::string{ "ed25519" },
+                    std::string{ "" });
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() ==
+                    std::string{ "Unable to parse seed: " });
+            }
+
+            BEAST_EXPECT(!exists(keyFile));
+        }
+    }
+
+    void
+    testRunCommand ()
+    {
+        testcase ("Run Command");
+
+        CoutRedirect coutRedirect;
+
+        using namespace boost::filesystem;
+
+        std::string const subdir = "test_key_file";
+        KeyFileGuard g(*this, subdir);
+        path const keyFile = subdir / ".ripple" / "secret-key.txt";
+
+        auto testCommand = [&](
+            std::string const& command,
+            std::vector <std::string> const& args,
+            std::string const& expectedError,
+            int const expectedExit = EXIT_FAILURE)
+        {
+            try
+            {
+                auto const inputType = args.empty() ? InputType::none :
+                    InputType::commandline;
+                auto const exit = runCommand(command, args, keyFile, {},
+                    inputType);
+                BEAST_EXPECT(exit == expectedExit);
+                BEAST_EXPECT(expectedError.empty());
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+        };
+
+        std::stringstream emptyinput;
+        CInRedirect cinRedirect{ emptyinput };
+
+        std::vector <std::string> const noArgs;
+        std::vector <std::string> const oneArg = { "some data" };
+        std::vector <std::string> const twoArgs = { "data", "more data" };
+        std::string const noError = "";
+        std::string const argError = "Syntax error: Wrong number of arguments";
+        {
+            std::string const command = "unknown";
+            std::string const expectedError = "Unknown command: " + command;
+            testCommand(command, noArgs, expectedError);
+            testCommand(command, oneArg, expectedError);
+            testCommand(command, twoArgs, expectedError);
+        }
+        {
+            std::string const command = "serialize";
+            testCommand(command, noArgs, argError);
+            testCommand(command, oneArg, noError);
+            testCommand(command, twoArgs, argError);
+        }
+        {
+            std::string const command = "deserialize";
+            testCommand(command, noArgs, argError);
+            testCommand(command, oneArg, noError);
+            testCommand(command, twoArgs, argError);
+        }
+        {
+            std::string const command = "sign";
+            testCommand(command, noArgs, argError);
+            testCommand(command, oneArg, noError);
+            testCommand(command, twoArgs, argError);
+        }
+        {
+            std::string const command = "multisign";
+            testCommand(command, noArgs, argError);
+            testCommand(command, oneArg, noError);
+            testCommand(command, twoArgs, argError);
+        }
+        {
+            std::string const command = "createkeyfile";
+            testCommand(command, noArgs, noError, EXIT_SUCCESS);
+            remove(keyFile);
+            testCommand(command, oneArg, noError, EXIT_SUCCESS);
+            remove(keyFile);
+            testCommand(command, twoArgs, argError);
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        BEAST_EXPECT(!getVersionString().empty());
+
+        testSerialize();
+        testDeserialize();
+        testSingleSign();
+        testMultiSign();
+        testCreateKeyfile();
+        testRunCommand ();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(OfflineTool, keys, serialize);
+
+} // test
+
+} // serialize

--- a/src/test/RippleKey_test.cpp
+++ b/src/test/RippleKey_test.cpp
@@ -1,0 +1,363 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <RippleKey.h>
+#include <Serialize.h>
+#include <test/KnownTestData.h>
+#include <test/KeyFileGuard.h>
+#include <ripple/basics/StringUtilities.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/json/json_reader.h>
+#include <ripple/protocol/JsonFields.h>
+
+namespace offline {
+
+namespace test {
+
+class RippleKey_test : public beast::unit_test::suite
+{
+private:
+    std::string const passphrase = "masterpassphrase";
+
+    void
+    testRandom(ripple::KeyType const kt)
+    {
+        using namespace ripple;
+
+        testcase("Random key");
+        RippleKey const key1(kt);
+        RippleKey const key2(kt);
+        // Not much you can check with a random key
+        BEAST_EXPECT(key1.keyType() == kt);
+        BEAST_EXPECT(key2.keyType() == kt);
+        BEAST_EXPECT(key1.publicKey() != key2.publicKey());
+        auto const pubkey1 = toBase58(TOKEN_ACCOUNT_PUBLIC, key1.publicKey());
+        auto const pubkey2 = toBase58(TOKEN_ACCOUNT_PUBLIC, key2.publicKey());
+        BEAST_EXPECT(pubkey1.length() == 52);
+        BEAST_EXPECT(pubkey2.length() == 52);
+        BEAST_EXPECT(pubkey1 != pubkey2);
+    }
+
+    void
+    testSeed(ripple::KeyType const kt)
+    {
+        using namespace ripple;
+
+        testcase("Known seed");
+
+        // Cases to check: string passphrase, string seed, and Seed
+        auto const seed = generateSeed(passphrase);
+
+        RippleKey const key(kt, seed);
+        auto const pubkey = toBase58(TOKEN_ACCOUNT_PUBLIC, key.publicKey());
+        BEAST_EXPECT(key.keyType() == kt);
+        BEAST_EXPECT(pubkey == (kt == KeyType::secp256k1 ?
+            "aBQG8RQAzjs1eTKFEAQXr2gS4utcDiEC9wmi7pfUPTi27VCahwgw" :
+            "aKGheSBjmCsKJVuLNKRAKpZXT6wpk2FCuEZAXJupXgdAxX5THCqR"));
+
+        auto const otherkeys = {
+            RippleKey::make_RippleKey(kt, passphrase),
+            RippleKey::make_RippleKey(kt, toBase58(seed)),
+            RippleKey::make_RippleKey(kt, strHex(seed.data(), seed.size())),
+            RippleKey::make_RippleKey(kt, seedAs1751(seed))
+        };
+        for (auto const& other : otherkeys)
+        {
+            BEAST_EXPECT(other.keyType() == kt);
+            BEAST_EXPECT(other.publicKey() == key.publicKey());
+        }
+    }
+
+    void
+    testFile(ripple::KeyType const kt)
+    {
+        using namespace boost::filesystem;
+
+        auto const key = RippleKey::make_RippleKey(kt, passphrase);
+
+        std::string const subdir = "test_key_file";
+        KeyFileGuard g(*this, subdir);
+        path const keyFile = subdir / ".ripple" / "secret-key.txt";
+
+        // Try some failure cases before writing the file
+        auto badFile = [&](const char* toWrite,
+            std::string const& expectedException)
+        {
+            path const badKeyFile = subdir / "bad-key.txt";
+            if(toWrite)
+            {
+                std::ofstream o(badKeyFile.string(), std::ios_base::trunc);
+                if (BEAST_EXPECT(!o.fail()))
+                {
+                    o << toWrite;
+                }
+            }
+            try
+            {
+                auto const keyBad = RippleKey::make_RippleKey(badKeyFile);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() ==
+                    std::string{ expectedException +
+                    badKeyFile.string() });
+            }
+        };
+        // No file
+        badFile(nullptr, "Failed to open key file: ");
+        // Write some nonsense to the file
+        badFile("{ seed = \"Hello, world\" }",
+            "Unable to parse json key file: ");
+        // Write valid but incomplete json to the file
+        badFile(R"({ "ponies": ["sparkleberry"] })",
+            "Field 'key_type' is missing from key file: ");
+        // Write a valid seed with an invalid keytype
+        badFile(R"({ "key_type": "sha1", "master_seed": "masterpassphrase" })",
+            R"(Invalid 'key_type' field "sha1" found in key file: )");
+        {
+            // Write a file over keyFile's directory
+            auto const badPath = keyFile.parent_path();
+            {
+                std::ofstream o(badPath.string(),
+                    std::ios_base::trunc);
+            }
+            try
+            {
+                key.writeToFile(keyFile);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() ==
+                    "Cannot create directory: " + badPath.string());
+            }
+            remove(badPath);
+            create_directories(keyFile);
+            try
+            {
+                key.writeToFile(keyFile);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() ==
+                    "Cannot open key file: " + keyFile.string());
+            }
+            remove_all(badPath);
+        }
+
+        key.writeToFile(keyFile);
+
+        auto const key2 = RippleKey::make_RippleKey(keyFile);
+        BEAST_EXPECT(key.keyType() == key2.keyType());
+        BEAST_EXPECT(key.publicKey() == key2.publicKey());
+
+        // Read the keyfile as a Json object to ensure it wrote
+        // what we expected
+        auto const jKeys = [&]
+        {
+            std::ifstream ifsKeys(keyFile.c_str(), std::ios::in);
+
+            if (BEAST_EXPECT(ifsKeys))
+            {
+
+                Json::Reader reader;
+                Json::Value jKeys;
+                BEAST_EXPECT(reader.parse(ifsKeys, jKeys));
+                return jKeys;
+            }
+            return Json::Value{};
+        }();
+
+        using namespace ripple;
+        auto const seed = generateSeed(passphrase);
+        auto const secretKey = generateKeyPair(kt, seed).second;
+
+        // Make sure there are no extra fields
+        BEAST_EXPECT(jKeys.size() == 9);
+        BEAST_EXPECT(jKeys[jss::account_id] ==
+            toBase58(calcAccountID(key.publicKey())));
+        BEAST_EXPECT(jKeys[jss::key_type] == to_string(kt));
+        BEAST_EXPECT(jKeys[jss::master_key] == seedAs1751(seed));
+        BEAST_EXPECT(jKeys[jss::master_seed] == toBase58(seed));
+        BEAST_EXPECT(jKeys[jss::master_seed_hex] ==
+            strHex(seed.data(), seed.size()));
+        BEAST_EXPECT(jKeys[jss::public_key] ==
+            toBase58(TOKEN_ACCOUNT_PUBLIC, key.publicKey()));
+        BEAST_EXPECT(jKeys[jss::public_key_hex] ==
+            strHex(key.publicKey().data(), key.publicKey().size()));
+        BEAST_EXPECT(jKeys["secret_key"] ==
+            toBase58(TOKEN_ACCOUNT_SECRET, secretKey));
+        BEAST_EXPECT(jKeys["secret_key_hex"] ==
+            strHex(secretKey.data(), secretKey.size()));
+    }
+
+    void
+    testSign(ripple::KeyType const kt)
+    {
+        using namespace offline;
+        using namespace ripple;
+
+        auto obj = deserialize(getKnownTxSigned().SerializedText);
+
+        if (!BEAST_EXPECT(obj))
+            return;
+
+        ripple::STTx tx{ std::move(*obj) };
+        // The hard-coded version is signed
+        auto check = tx.checkSign(true);
+        BEAST_EXPECT(check.first);
+        {
+            auto const key = RippleKey::make_RippleKey(kt,
+                std::string("alice"));
+            auto const expectedSignature = kt == KeyType::secp256k1 ?
+                tx.getFieldVL(sfTxnSignature) :
+                strUnHex("0751E8D38C26E8B6C953766A8A58570CA0CB93E57B86047F1FEF8DA3D7"
+                    "9DFB97E78F4E59365C88EEE0E94EF7C1A2155A828B239AC00F3E95802D"
+                    "851ABB113F06").first;
+            auto const expectedSigningKey = kt == KeyType::secp256k1 ?
+                tx.getFieldVL(sfSigningPubKey) :
+                strUnHex("ED4A9D72F2557B714713DC8BA7C6F9576BCC06117A52F6C32"
+                    "F1E26FEEF9819EC8E").first;
+
+            // Remove the signature
+            tx.makeFieldAbsent(sfTxnSignature);
+            tx.setAccountID(sfAccount, calcAccountID(key.publicKey()));
+            check = tx.checkSign(true);
+            BEAST_EXPECT(!check.first);
+            BEAST_EXPECT(check.second == "Invalid signature.");
+
+            // Now re-sign it
+            key.singleSign(tx);
+            BEAST_EXPECT(tx.checkSign(true).first);
+            // Same signature
+            BEAST_EXPECT(tx.getFieldVL(sfSigningPubKey) == expectedSigningKey);
+            BEAST_EXPECT(tx.getFieldVL(sfTxnSignature) == expectedSignature);
+            BEAST_EXPECT(!tx.isFieldPresent(sfSigners));
+        }
+
+        {
+            // Use a different key to multisign, because an account can't
+            // multisign its own transaction.
+            auto const key = RippleKey::make_RippleKey(kt, std::string("bob"));
+
+            // Now multisign it with the test key
+            key.multiSign(tx);
+            BEAST_EXPECT(tx.checkSign(true).first);
+            // No single signature
+            BEAST_EXPECT(!tx.isFieldPresent(sfTxnSignature));
+            BEAST_EXPECT(tx.getFieldVL(sfSigningPubKey).empty());
+            if (BEAST_EXPECT(tx.isFieldPresent(sfSigners)))
+            {
+                auto const& signers = tx.getFieldArray(sfSigners);
+                BEAST_EXPECT(signers.size() == 1);
+                auto const& signer = signers[0];
+                auto const expectedAccount = kt == KeyType::secp256k1 ?
+                    "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK" :
+                    "rJy554HmWFFJQGnRfZuoo8nV97XSMq77h7";
+                auto const expectedPubKey = kt == KeyType::secp256k1 ?
+                    "02691AC5AE1C4C333AE5DF8A93BDC495F0EEBFC6DB0DA7EB6"
+                    "EF808F3AFC006E3FE" :
+                    "ED3CC3D14FD80C213BC92A98AFE13A405A030F845EDCFD5E3"
+                    "95286A6E9E62BA638";
+                auto const expectedSignature = kt == KeyType::secp256k1 ?
+                    "304402200719B97DA805D72C51100ECFEA86F73B7AC787559E"
+                    "1AB34285C82CD0C7EC0A1402206EDDE8077DB49F808ED1BFC6"
+                    "6CC06B944A11F05B58D59247B027B40F04E95412" :
+                    "D12E9335B9AADAB917E65F5E3DB4B8A37DB0F5F5DC2E7333FF"
+                    "26A8E5FEEC203D1F65ACADE6E6D0BD8E01D21C1838DF005E66"
+                    "9AC1C8E57CA41405374CEDBB2309";
+                BEAST_EXPECT(to_string(signer.getAccountID(sfAccount)) ==
+                    expectedAccount);
+                BEAST_EXPECT(strHex(signer.getFieldVL(sfSigningPubKey)) ==
+                    expectedPubKey);
+                BEAST_EXPECT(strHex(signer.getFieldVL(sfTxnSignature)) ==
+                    expectedSignature);
+            }
+
+            // Sign with a second key
+            auto const key2 = RippleKey::make_RippleKey(kt,
+                passphrase);
+            key2.multiSign(tx);
+            BEAST_EXPECT(tx.checkSign(true).first);
+            // No single signature
+            BEAST_EXPECT(!tx.isFieldPresent(sfTxnSignature));
+            BEAST_EXPECT(tx.getFieldVL(sfSigningPubKey).empty());
+            if (BEAST_EXPECT(tx.isFieldPresent(sfSigners)))
+            {
+                auto const& signers = tx.getFieldArray(sfSigners);
+                BEAST_EXPECT(signers.size() == 2);
+                BEAST_EXPECT(signers[0].getAccountID(sfAccount) <
+                    signers[1].getAccountID(sfAccount));
+                // Because the masterpassphrase accountid happens to
+                // sort before "bob" for both keytypes, the new
+                // signature is inserted up front.
+                auto const& signer = signers[0];
+                auto const expectedAccount = kt == KeyType::secp256k1 ?
+                    "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh" :
+                    "rGWrZyQqhTp9Xu7G5Pkayo7bXjH4k4QYpf";
+                auto const expectedPubKey = kt == KeyType::secp256k1 ?
+                    "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32"
+                    "654A313222F7FD020" :
+                    "EDAAC3F98BB94F451804EF5993C847DAAA4E6154F45563565"
+                    "9D88AA5C80F156303";
+                auto const expectedSignature = kt == KeyType::secp256k1 ?
+                    "3045022100C2496C05E17E3239837D7404F715A1C932FE286A"
+                    "0540460D13E8BF4C9E4A7E3802205A3CED19AB8D924E8BDBD3"
+                    "F14D74B6AB35BEDD62CEC936F138C35AC4EAFDBD83" :
+                    "95103211B25FD07976C76D1BD0B205B37887F9F3799BA91402"
+                    "1B40A6906723F47A78B66E141204E0123660F8C9D0B3F1263A"
+                    "8119F4523EDB3FE6C594BFBA3603";
+                BEAST_EXPECT(to_string(signer.getAccountID(sfAccount)) ==
+                    expectedAccount);
+                BEAST_EXPECT(strHex(signer.getFieldVL(sfSigningPubKey)) ==
+                    expectedPubKey);
+                BEAST_EXPECT(strHex(signer.getFieldVL(sfTxnSignature)) ==
+                    expectedSignature);
+            }
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        using namespace ripple;
+
+        std::array<KeyType, 2> constexpr keyTypes{ {
+                KeyType::secp256k1,
+                KeyType::ed25519 } };
+
+        for (auto const& kt : keyTypes)
+        {
+            testRandom(kt);
+            testSeed(kt);
+            testFile(kt);
+            testSign(kt);
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(RippleKey, keys, serialize);
+
+} // test
+
+} // serialize

--- a/src/test/Serialize_test.cpp
+++ b/src/test/Serialize_test.cpp
@@ -1,0 +1,250 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of ripple-offline-tool:
+        https://github.com/ximinez/ripple-offline-tool
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <Serialize.h>
+#include <RippleKey.h>
+#include <test/KnownTestData.h>
+#include <test/KeyFileGuard.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/Sign.h>
+#include <ripple/protocol/TxFlags.h>
+#include <beast/core/detail/base64.hpp>
+
+namespace offline {
+
+namespace test {
+
+class Serialize_test : public beast::unit_test::suite
+{
+private:
+    void verifyKnownTx(ripple::STTx const& obj)
+    {
+        using namespace ripple;
+        BEAST_EXPECT(to_string(obj.getTransactionID()) ==
+            "F2D008D2AABBABD2A882F9049AA873210908EC3EA1EB0A2044A66093C7ACD2B1");
+        BEAST_EXPECT(obj[sfTransactionType] == ttPAYMENT);
+        BEAST_EXPECT(obj[sfFlags] == tfFullyCanonicalSig);
+        BEAST_EXPECT(toBase58(obj[sfAccount]) ==
+            "rG1QQv2nh2gr7RCZ1P8YYcBUKCCN633jCn");
+        BEAST_EXPECT(obj[sfSequence] == 18);
+        BEAST_EXPECT(obj[sfFee] == STAmount(100));
+        BEAST_EXPECT(strHex(obj[sfSigningPubKey]) ==
+            "0388935426E0D08083314842EDFBB2D517BD47699F9A4527318A8E10468C97C052");
+        BEAST_EXPECT(strHex(obj[sfTxnSignature]) ==
+            "3044022030425DB6A46B5B57BDA85E5B8455B90DC4EC57BA1A707AF0C"
+            "28DC9383E09643D0220195B9FDBE383B813A539F3B70E130482E92D1E"
+            "1210B0F85551E11B3F81EB98BB");
+        BEAST_EXPECT(toBase58(obj[sfDestination]) ==
+            "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh");
+        auto const amountAccount = parseBase58<AccountID>(
+            "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq");
+        if (BEAST_EXPECT(amountAccount))
+        {
+            BEAST_EXPECT(obj[sfAmount] == STAmount(
+                Issue(to_currency("USD"), *amountAccount),
+                    123400000));
+        }
+        auto const sendMaxAccount = parseBase58<AccountID>(
+            "razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA");
+        if (BEAST_EXPECT(sendMaxAccount))
+        {
+            // Need a variable here instead of a literal to make
+            // some compilers happy
+            const std::uint64_t mantissa = 5678900000000000LLU;
+            BEAST_EXPECT(obj[sfSendMax] == STAmount(
+                Issue(to_currency("CNY"), *sendMaxAccount),
+                mantissa, -4));
+        }
+    }
+
+    void testParseJson()
+    {
+        testcase("ParseJson");
+
+        auto const& testTx = getKnownTxSigned();
+        auto json = parseJson(testTx.JsonText);
+        BEAST_EXPECT(json);
+
+        // Don't need to test the `JsonReader`, just a case to ensure the wrapper
+        // handles failures
+        json = parseJson("{ asjlfkjs");
+        BEAST_EXPECT(!json);
+    }
+
+    void testMakeObject()
+    {
+        testcase("Make Object");
+
+        auto const& testTx = getKnownTxSigned();
+        auto json = parseJson(testTx.JsonText);
+        auto obj = makeObject(json);
+        if (BEAST_EXPECT(obj))
+        {
+            ripple::STTx tx{ std::move(*obj) };
+            verifyKnownTx(tx);
+        }
+    }
+
+    void testSerialize()
+    {
+        testcase("Serialize");
+
+        auto test = [&](TestItem const& testItem)
+        {
+            auto const json = parseJson(testItem.JsonText);
+            auto const obj = makeObject(json);
+            if (BEAST_EXPECT(obj))
+            {
+                auto const serialized = offline::serialize(*obj);
+                BEAST_EXPECT(testItem.SerializedText == serialized);
+            }
+        };
+
+        test(getKnownTxSigned());
+        test(getKnownTxUnsigned());
+        test(getKnownMetadata());
+    }
+
+    void testDeserialize()
+    {
+        testcase("Deserialize");
+
+        auto test = [&](TestItem const& testItem,
+            std::function<bool(ripple::STObject&,
+                Json::Value const& known)> extra = nullptr)
+        {
+            try
+            {
+                auto obj = deserialize(testItem.SerializedText);
+
+                if (BEAST_EXPECT(obj))
+                {
+                    auto check = true;
+                    auto const known = parseJson(testItem.JsonText);
+                    if (extra)
+                        check = extra(*obj, known);
+                    if (check)
+                    {
+                        BEAST_EXPECT(obj->getJson(0) == known);
+                    }
+                }
+            }
+            catch (...)
+            {
+                fail();
+            }
+        };
+
+        test(getKnownTxSigned(), [&](auto& obj, auto const& known)
+        {
+            ripple::STTx tx{ std::move(obj) };
+            this->verifyKnownTx(tx);
+            this->BEAST_EXPECT(tx.getJson(0) == known);
+            return false;
+        });
+        test(getKnownTxUnsigned());
+        test(getKnownMetadata());
+    }
+
+    void testMakeSttx()
+    {
+        testcase("Make Sttx");
+
+        using namespace boost::filesystem;
+        using namespace ripple;
+
+        {
+            // golden path
+            auto const& known = getKnownTxSigned();
+            auto const origTx = offline::deserialize(known.SerializedText);
+            if (BEAST_EXPECT(origTx))
+            {
+                {
+                    auto const tx = offline::make_sttx(known.SerializedText);
+                    BEAST_EXPECT(tx[sfSigningPubKey] ==
+                        (*origTx)[sfSigningPubKey]);
+                    BEAST_EXPECT(tx[sfTxnSignature] ==
+                        (*origTx)[sfTxnSignature]);
+                    BEAST_EXPECT(tx.checkSign(true).first);
+                }
+                {
+                    auto const tx = offline::make_sttx(known.JsonText);
+                    BEAST_EXPECT(tx[sfSigningPubKey] ==
+                        (*origTx)[sfSigningPubKey]);
+                    BEAST_EXPECT(tx[sfTxnSignature] ==
+                        (*origTx)[sfTxnSignature]);
+                    BEAST_EXPECT(tx.checkSign(true).first);
+                }
+            }
+        }
+        {
+            // send sensible data that does not make a Tx
+            auto const& known = getKnownMetadata();
+            try
+            {
+                offline::make_sttx(known.SerializedText);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(std::string{ e.what() } == "Field not found");
+            }
+            try
+            {
+                offline::make_sttx(known.JsonText);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(std::string{ e.what() } == "Field not found");
+            }
+        }
+        {
+            // send nonsense
+            try
+            {
+                auto const tx = offline::make_sttx("{ txtype = noop");
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(std::string{ e.what() } == "invalid JSON");
+            }
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        testParseJson();
+        testMakeObject();
+        testSerialize();
+        testDeserialize();
+        testMakeSttx();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Serialize, keys, serialize);
+
+} // test
+
+} // serialize


### PR DESCRIPTION
This tool can serialize and deserialize any STObject-based
object used by the rippled RPC API (notable exception:
Ledger data uses a currently incompatible format), and
add a single-signature or multi-signature to a transaction.

* Version 0.1.0
* Uses ripple-libpp version 1.0.0-b4.

