### PR TITLE
ripple-offline-tool multisign now returns correct hash

### DIFF
--- a/src/OfflineTool.cpp
+++ b/src/OfflineTool.cpp
@@ -135,7 +135,7 @@ int
 doSign(std::string const& data,
     boost::filesystem::path const& keyFile,
     std::function<void(offline::RippleKey const& key,
-        ripple::STTx& tx)> signingOp)
+        boost::optional<ripple::STTx>& tx)> signingOp)
 {
     using namespace offline;
     auto const fail = [&]()
@@ -158,7 +158,7 @@ doSign(std::string const& data,
         BOOST_ASSERT(tx);
         auto const rippleKey = RippleKey::make_RippleKey(keyFile);
 
-        signingOp(rippleKey, *tx);
+        signingOp(rippleKey, tx);
 
         std::cout << tx->getJson(0).toStyledString() << std::endl;
         return EXIT_SUCCESS;
@@ -175,20 +175,22 @@ int
 doSingleSign(std::string const& data,
     boost::filesystem::path const& keyFile)
 {
-    return doSign(data, keyFile, [](auto const& key, auto& tx)
-    {
-        key.singleSign(tx);
-    });
+    return doSign(data, keyFile,
+        [](offline::RippleKey const& key, boost::optional<ripple::STTx>& tx)
+        {
+            key.singleSign(tx);
+        });
 }
 
 int
 doMultiSign(std::string const& data,
     boost::filesystem::path const& keyFile)
 {
-    return doSign(data, keyFile, [](auto const& key, auto& tx)
-    {
-        key.multiSign(tx);
-    });
+    return doSign(data, keyFile,
+        [](offline::RippleKey const& key, boost::optional<ripple::STTx>& tx)
+        {
+            key.multiSign(tx);
+        });
 }
 
 int

--- a/src/RippleKey.h
+++ b/src/RippleKey.h
@@ -98,14 +98,14 @@ public:
         @param tx Transaction to single sign
     */
     void
-    singleSign(ripple::STTx& tx) const;
+    singleSign(boost::optional<ripple::STTx>& tx) const;
 
     /** Add a signer to the transaction with the key
 
         @param tx Transaction to multi sign
     */
     void
-    multiSign(ripple::STTx& tx) const;
+    multiSign(boost::optional<ripple::STTx>& tx) const;
 
     /// KeyType of this key
     ripple::KeyType const&


### PR DESCRIPTION
Due to some obscure caching in ripple::STTx, an extra step is required to get the correct hash into a multisigned STTx.  That step is added along with slightly expanded unit tests.