### PR TITLE
Improve handling of Json parsing errors

### DIFF
--- a/src/Serialize.cpp
+++ b/src/Serialize.cpp
@@ -25,6 +25,7 @@
 #include <ripple/basics/strHex.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/Sign.h>
 #include <boost/filesystem.hpp>
@@ -49,6 +50,8 @@ makeObject(Json::Value const& json)
     using namespace ripple;
 
     STParsedJSONObject parsed("", json);
+    if (!parsed.object)
+        throw std::runtime_error(rpcErrorString(parsed.error));
 
     return parsed.object;
 }
@@ -96,6 +99,8 @@ make_sttx(std::string const& data)
         if (json)
             obj = offline::makeObject(json);
         else
+            throw std::runtime_error("invalid JSON");
+        if (!obj)
             throw std::runtime_error("invalid JSON");
     }
 

--- a/src/test/Serialize_test.cpp
+++ b/src/test/Serialize_test.cpp
@@ -252,6 +252,42 @@ private:
         }
     }
 
+    void
+    testBad()
+    {
+        testcase("Bad input");
+
+        // This transaction has a DestinationTag larger than 32-bits
+        std::string const bad{
+            R"({
+                "Account" : "rDAE53VfMvftPB4ogpWGWvzkQxfht6JPxr",
+                "Amount" : "89031976",
+                "Destination" : "rU2mEJSLqBRkYLVTv55rFTgQajkLTnT6mA",
+                "DestinationTag" : 641505641505,
+                "Fee" : "10000",
+                "Flags" : 0,
+                "LastLedgerSequence" : 68743734,
+                "Sequence" : 68133057,
+                "TransactionType" : "Payment"
+            })"};
+        {
+            auto json = parseJson(bad);
+            BEAST_EXPECT(json);
+            try
+            {
+                auto obj = makeObject(json);
+                fail();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(
+                    e.what() ==
+                    std::string(
+                        "invalidParamsField '.DestinationTag' has bad type."));
+            }
+        }
+    }
+
 public:
     void
     run() override
@@ -261,6 +297,7 @@ public:
         testSerialize();
         testDeserialize();
         testMakeSttx();
+        testBad();
     }
 };
 


### PR DESCRIPTION
Json parsing result wasn't checked, leading to potential use of malformed `STObject`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ximinez/ripple-offline-tool/14)
<!-- Reviewable:end -->
